### PR TITLE
Increase hackney timeout

### DIFF
--- a/lib/sns/local/pub_sub.ex
+++ b/lib/sns/local/pub_sub.ex
@@ -1,6 +1,8 @@
 defmodule SNS.Local.PubSub do
   use GenServer
 
+  @max_timeout 30_000
+
   def start_link(opts) do
     name = Keyword.get(opts, :name, __MODULE__)
 
@@ -33,6 +35,12 @@ defmodule SNS.Local.PubSub do
 
   defp do_publish(endpoint, message) do
     json = Jason.encode!(%{"Type" => "Notification", "Message" => message})
-    :hackney.post(endpoint, [{"content-type", "application/json"}], json)
+
+    :hackney.post(
+      endpoint,
+      [{"content-type", "application/json"}],
+      json,
+      {:recv_timeout, @max_timeout}
+    )
   end
 end


### PR DESCRIPTION
Hackney's default is 5 seconds, increasing to 30 should be more than enough to roll messages without the GenServer going down.